### PR TITLE
Fix utf-8 character output on Windows

### DIFF
--- a/convert_notes.py
+++ b/convert_notes.py
@@ -457,5 +457,5 @@ for fpath in new_paths:
 
             newlines.append(line)
 
-    with open(fpath, "w") as f:
+    with open(fpath, "w", encoding="utf-8") as f:
         f.writelines(newlines)


### PR DESCRIPTION
If I have UTF-8 character in my Logseq source file (for my case, "฿" symbol), when I convert notes on Windows, I get an error. This PR resolves this issue.